### PR TITLE
Add missing Nissan Primera 2.0 Te '90 to random prize cars list

### DIFF
--- a/src/projects/gt4o_us/gtmode/PresentRoot.ad
+++ b/src/projects/gt4o_us/gtmode/PresentRoot.ad
@@ -485,7 +485,7 @@ module GTmodeProject::PresentRoot::CarPane
         {
             if (randomizer_enabled == 1)
             {
-                car = PresentData::allcars_carlist[main::menu::MRandom::GetValue(0, PresentData::allcars_carnum-1, fnv1a(main::game.username + race + func))];
+                car = PresentData::allcars_carlist[main::menu::MRandom::GetValue(0, PresentData::allcars_carnum, fnv1a(main::game.username + race + func))];
                 col = "-";
                 Shuffle.visible = true;
             }

--- a/src/projects/gt4o_us/gtmode/US_carlist.ad
+++ b/src/projects/gt4o_us/gtmode/US_carlist.ad
@@ -1506,6 +1506,7 @@ module PresentData
         "prelude_si_vtec_91",
         "prelude_sir_96",
         "prelude_sir_s_98",
+        "primera_20te_90",
         "primera_20v_us_01",
         "prius_g_02",
         "prius_g_touring_03",


### PR DESCRIPTION
Add the missing `primera_20te_90` car label to `PresentData::allcars_carlist`, which brings its length to match `PresentData::allcars_carnum`. This allows it to be selected as a random prize by the prize car randomizer.

Also adjusted the max bound of the `MRandom::GetValue` call for random prize cars to compensate.